### PR TITLE
Fix library on webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ spotify.search.artists('Incubus');
 ### CommonJS
 
 ```js
-const spotifyWrapper = require('spotify-wrapper');
+const SpotifyWrapper = require('spotify-wrapper');
 
 const spotify = new SpotifyWrapper({
   token: 'YOUR_TOKEN_HERE'

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -7,7 +7,7 @@ export default {
   output: {
     path: join(__dirname, 'dist'),
     libraryTarget: 'umd',
-    library: 'spotifyWrapper',
+    library: 'SpotifyWrapper',
   },
   devtool: 'source-map',
   module: {


### PR DESCRIPTION
Just fixing the library name given in webpack config so thar the example/index.html can work, otherwise you get ` Uncaught ReferenceError: SpotifyWrapper is not defined at index.html:14`