### PR TITLE
Fix getAlbums method

### DIFF
--- a/src/album.js
+++ b/src/album.js
@@ -1,7 +1,7 @@
 export default function album() {
   return {
     getAlbum: id => this.request(`${this.apiURL}/albums/${id}`),
-    getAlbums: ids => this.request(`${this.apiURL}/albums/?ids=${ids}`),
+    getAlbums: ids => this.request(`${this.apiURL}/albums?ids=${ids}`),
     getTracks: id => this.request(`${this.apiURL}/albums/${id}/tracks`),
   };
 }

--- a/tests/album.spec.js
+++ b/tests/album.spec.js
@@ -72,7 +72,7 @@ describe('Album', () => {
     it('should call fetch with the correct URL', () => {
       const albums = spotify.album.getAlbums(['4aawyAB9vmqN3uQ7FjRGTy', '4aawyAB9vmqN3uQ7FjRGTk']);
       expect(stubedFetch).to.have.been
-        .calledWith('https://api.spotify.com/v1/albums/?ids=4aawyAB9vmqN3uQ7FjRGTy,4aawyAB9vmqN3uQ7FjRGTk');
+        .calledWith('https://api.spotify.com/v1/albums?ids=4aawyAB9vmqN3uQ7FjRGTy,4aawyAB9vmqN3uQ7FjRGTk');
     });
 
     it('should return the correct data from Promise', () => {


### PR DESCRIPTION
According to the API documentation, the getAlbums method should be "https://api.spotify.com/v1/albums?ids=id1,id2